### PR TITLE
Fix wrong namespace separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Wrong:
 ```php
 <?php
 
-namespace Some/Namespace;
+namespace Some\Namespace;
 
 // ...
 
@@ -509,7 +509,7 @@ Right:
 ```php
 <?php
 
-namespace Some/Namespace;
+namespace Some\Namespace;
 
 use Vendor\Namespace\Entity\Value;
 


### PR DESCRIPTION
Fix wrong namespace separator in the _Namespaces and use statements_ section.