### PR TITLE
Updated PhpDoc convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,7 +1391,7 @@ public function processTransfers(array $transfers): void;
  * @dataProvider dataProviderForSomeMethodTest
  * @throws Exception    
  */
-public function testSomeMethod(array $input, string $expectation): void;
+public function testSomeMethod(int $input, string $expectation): void;
 ```
 
 #### PhpDoc on arrays


### PR DESCRIPTION
Updated PhpDoc convention, following changed:
- PhpDoc should only contain information that is not available in method signature in order to avoid dublication
- Added real-world examples from regular code and source code
- Remove section that dictates that phpdoc should contain full info
- Fixed typo